### PR TITLE
Timeline drag/zoom fixes

### DIFF
--- a/qml/SignalRow.qml
+++ b/qml/SignalRow.qml
@@ -114,17 +114,28 @@ Rectangle {
           gridColor: '#111'
           textColor: '#444'
         }
+        PropertyChanges { target: axes_mouse_area
+          drag.target: axes
+          drag.axis: Drag.YAxis
+        }
         PropertyChanges { target: overlay_periodic; visible: false }
         PropertyChanges { target: overlay_constant; visible: false }
       }
     ]
 
     MouseArea {
+      id: axes_mouse_area
       anchors.fill: parent
-      drag.target: axes
-      drag.axis: Drag.YAxis
-      onDoubleClicked: {axes.state = "floating"}
-      onReleased: {axes.state = "notfloating"}
+
+      acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+      onPressed: {
+        if (mouse.button == Qt.MiddleButton) {
+          axes.state = "floating"
+        } else {
+          mouse.accepted = false;
+        }
+      }
+      onReleased: {axes.state = ""}
       onWheel: {
       // Shift + scroll for Y-axis zoom
         if (wheel.modifiers & Qt.ShiftModifier) {

--- a/qml/SignalRow.qml
+++ b/qml/SignalRow.qml
@@ -108,10 +108,14 @@ Rectangle {
     states: [
       State {
         name: "floating"
-        PropertyChanges { target: axes; anchors.top: undefined; anchors.bottom: undefined; }
+        PropertyChanges { target: axes
+          anchors.top: undefined
+          anchors.bottom: undefined
+          gridColor: '#111'
+          textColor: '#444'
+        }
         PropertyChanges { target: overlay_periodic; visible: false }
         PropertyChanges { target: overlay_constant; visible: false }
-        PropertyChanges { target: axes; gridColor: '#111'; textColor: '#444' }
       }
     ]
 


### PR DESCRIPTION
This fixes the drag-to-pan functionality that is probably the most desirable click action.

It changes drag-to-compare to be middle-click drag. Alternatives include ctrl-drag, or finding a workaround to detect a double-click while passing other events through.